### PR TITLE
feat: add changes for installing and updating with HACS

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   hassfest: # https://developers.home-assistant.io/blog/2020/04/16/hassfest

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -7,8 +7,22 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  validate:
+  hassfest: # https://developers.home-assistant.io/blog/2020/04/16/hassfest
+    name: Hassfest validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: "actions/checkout@v4.2.2"
+      - name: validation
+        uses: home-assistant/actions/hassfest@master
+
+  validate-hacs: # https://github.com/hacs/action
+    name: HACS validation
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: home-assistant/actions/hassfest@master
+      - name: checkout
+        uses: "actions/checkout@v4.2.2"
+      - name: validation
+        uses: "hacs/action@main"
+        with:
+          category: "integration"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,26 @@ Geyserwala - Home Assistant Integration <!-- omit in toc -->
 
 # Installing into Home Assistant
 At present this integration is a custom integration, a few steps are required to install it into your Home Assistant:
+
+## Installing using [HACS](https://hacs.xyz/)
+
+* Add this repo as an integration custom repo:
+  * On the side bar menu select "**HACS**"..
+  * Click the three dot menu in the top right.
+  * Click on "**Custom repositories**".
+  * Paste `https://github.com/thingwala/geyserwala-ha` into the "**Repository**" field.
+  * Set the type to "**Integration**".
+  * Click "**Add**".
+* Search for "**Geyserwala**".
+* Click on the integration.
+* Click "**Download**" in the bottom right.
+* Click "**Download**" in the popup.
+* On the side bar menu select "**Developer Tools**".
+* At the bottom left of the "**Check and Restart**" panel, click "**CHECK CONFIGURATION**".
+* If you see "*Configuration will not prevent Home Assistant from starting!*", then click "**RESTART**" at the bottom right of the panel.
+
+## Installing custom integration manually
+
 * Download this repository as a ZIP file by clicking this [link](https://github.com/thingwala/geyserwala-ha/zipball/main).
 * Uncompress the ZIP file, and browse into it.
 * Move/copy the `thingwala_geyserwala` folder to `.../homeassistant/core/config/custom_components/thingwala_geyserwala`.

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,4 @@
+{
+    "name": "Geyserwala",
+    "homeassistant": "2025.1.4"
+}


### PR DESCRIPTION
This pull request adds HACS compatibility. This allows users to install it more easily and also handles updating for the user.

I needed to specifically change 2 things on my fork to get it to work with HACS:
- I needed to enable `issues` on the repo
- I needed to add tags to the repo so I added "[home-assistant](https://github.com/topics/home-assistant) [hacs-integration](https://github.com/topics/hacs-integration) [geyserwala](https://github.com/topics/geyserwala) [geyserwise](https://github.com/topics/geyserwise) [thingwala](https://github.com/topics/thingwala)"

### Workflow updates:
* [`.github/workflows/hassfest.yaml`](diffhunk://#diff-1ac46986a8988cdd5278f7aaa408779d0cff148ec22a0bb78aefbf5ab4af9beaR8-R29): Added a `workflow_dispatch` trigger and restructured jobs to include separate steps for "Hassfest validation" and "HACS validation". Updated the `checkout` action to version `v4.2.2`.

### HACS support:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R8-R27): Added detailed instructions for installing the integration using HACS, making it easier for users to add the integration via the Home Assistant Community Store.
* [`hacs.json`](diffhunk://#diff-2004f3033aaa650b74a155b56a1e6110e85583824c83f3cb5a0c2856bd00483fR1-R4): Introduced a new `hacs.json` file to define metadata for HACS compatibility, specifying the integration name and minimum Home Assistant version.